### PR TITLE
feature: 소속 도메인 설계

### DIFF
--- a/src/main/java/com/eod/sitree/belonging/domain/model/Belonging.java
+++ b/src/main/java/com/eod/sitree/belonging/domain/model/Belonging.java
@@ -1,0 +1,21 @@
+package com.eod.sitree.belonging.domain.model;
+
+
+public class Belonging {
+
+    private final Long belongingId;
+
+    private final BelongingType type;
+
+    private final String name;
+
+    private final String imageUrl;
+
+
+    public Belonging(Long belongingId, BelongingType type, String name, String imageUrl) {
+        this.belongingId = belongingId;
+        this.type = type;
+        this.name = name;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/com/eod/sitree/belonging/domain/model/BelongingType.java
+++ b/src/main/java/com/eod/sitree/belonging/domain/model/BelongingType.java
@@ -1,0 +1,8 @@
+package com.eod.sitree.belonging.domain.model;
+
+public enum BelongingType {
+
+    HIGH_SCHOOL,
+    UNIVERSITY,
+    CORPORATION
+}


### PR DESCRIPTION
학교 및 기업 대상 Enum 타입이 10k가 넘어가므로 데이터베이스로 관리하는 것이 메모리 측면이나 기능(DB 검색 기능등) 측면에서 이점이 있을것으로 생각됨.

엔티티도 도메인과 거의 동일하게 생성될 것입니다.