### PR TITLE
feature: ResourceHttpRequestHandler 토큰 인증 제외 및 NoResourceFoundException 404 처리

### DIFF
--- a/src/main/java/com/eod/sitree/auth/support/AuthenticationInterceptor.java
+++ b/src/main/java/com/eod/sitree/auth/support/AuthenticationInterceptor.java
@@ -9,6 +9,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.resource.ResourceHttpRequestHandler;
 
 @RequiredArgsConstructor
 public class AuthenticationInterceptor implements HandlerInterceptor {
@@ -19,7 +20,8 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
         Object handler) throws Exception {
 
-        if (checkAnnotation(handler, AuthNotRequired.class) || request.getMethod().equals("OPTIONS")) {
+        if (checkAnnotation(handler, AuthNotRequired.class) || request.getMethod().equals("OPTIONS") || handler.getClass().equals(
+            ResourceHttpRequestHandler.class)) {
             return true;
         }
 

--- a/src/main/java/com/eod/sitree/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/eod/sitree/common/exception/handler/GlobalExceptionHandler.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
 @RestControllerAdvice
@@ -76,6 +77,13 @@ public class GlobalExceptionHandler {
         log.info("{}", e.getMessage());
         e.printStackTrace(System.err);
         return getResponse(HttpStatus.UNAUTHORIZED, e.getMessage());
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ResponseDto<String>> handleIllegalArgumentException(NoResourceFoundException e) {
+        log.info("{}", e.getMessage());
+        e.printStackTrace(System.err);
+        return getResponse(HttpStatus.NOT_FOUND, e.getMessage());
     }
 
     @ExceptionHandler(AuthException.class)


### PR DESCRIPTION
이슈 원인
- 없는 path에 대한 요청이 들어올 경우 ResourceHttpRequestHandler 가 매핑됨
- ResourceHttpRequestHandler 도 interceptor prehandle() 과정에서 토큰 검증을 거치게됨. 
  - 토큰이 없는 경우 JWT token empty 가 반환됨 -> 맞지 않는 예외임
  - JWT 토큰 검증 로직을 넘어갔다 해도 NoResourceFoundException 으로 500 에러 발생

조치사항
- ResourceHttpRequestHandler에 대해서는 토큰 검증을 하지도 않도록 수정
- NoResourceFoundException 발생시 404 NOT FOUND 처리

고민사항
- 위 방법 외에 ResourceHttpRequestHandler를 아예 handler 목록에서 제외하는 방안도 있음