### PR TITLE
feat: 프로젝트 목록 수정, 참여자 프로젝트 목록 조회 (focusedOn 작성여부 포함)

### DIFF
--- a/src/main/java/com/eod/sitree/project/domain/modelRepository/ProjectRepository.java
+++ b/src/main/java/com/eod/sitree/project/domain/modelRepository/ProjectRepository.java
@@ -2,6 +2,7 @@ package com.eod.sitree.project.domain.modelRepository;
 
 import com.eod.sitree.project.domain.model.Project;
 import com.eod.sitree.project.ui.dto.request.ProjectListRequestDto;
+import com.eod.sitree.project.ui.dto.response.ParticipatedProjectsResponseDto;
 import com.eod.sitree.project.ui.dto.response.ProjectListResponseDto.ProjectDisplayElement;
 import com.eod.sitree.project.ui.dto.response.SitreePickGetResponse;
 import java.util.List;
@@ -27,4 +28,6 @@ public interface ProjectRepository {
     boolean toggleLike(long projectId, long memberId);
 
     List<SitreePickGetResponse> getSitreeSuggestion();
+
+    List<ParticipatedProjectsResponseDto> getParticipatedProjects(long memberId);
 }

--- a/src/main/java/com/eod/sitree/project/service/ProjectService.java
+++ b/src/main/java/com/eod/sitree/project/service/ProjectService.java
@@ -15,6 +15,7 @@ import com.eod.sitree.project.ui.dto.response.ProjectListResponseDto;
 import com.eod.sitree.project.ui.dto.response.SitreePickGetResponse;
 import jakarta.transaction.Transactional;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -62,7 +63,7 @@ public class ProjectService {
 
     public ProjectListResponseDto getProjectList(Pageable pageable, ProjectListRequestDto dto) {
         var result = projectRepository.getListBySearchType(pageable, dto);
-        result.getContent().forEach(p -> {
+        result.getContent().parallelStream().forEach(p -> {
             boolean healthy = clientRequestService.isHealthy(p.getHealthCheckUrl());
             p.setIsHealthy(healthy);
         });
@@ -83,7 +84,7 @@ public class ProjectService {
     public List<ParticipatedProjectsResponseDto> getParticipatedProjects(Long memberId){
         List<ParticipatedProjectsResponseDto> participatedProjects = projectRepository.getParticipatedProjects(
                 memberId);
-        participatedProjects.forEach(p -> {
+        participatedProjects.parallelStream().forEach(p -> {
             boolean healthy = clientRequestService.isHealthy(p.getHealthCheckUrl());
             p.setIsHealthy(healthy);
         });

--- a/src/main/java/com/eod/sitree/project/service/ProjectService.java
+++ b/src/main/java/com/eod/sitree/project/service/ProjectService.java
@@ -7,6 +7,7 @@ import com.eod.sitree.project.exeption.ProjectException;
 import com.eod.sitree.project.infra.ClientRequestServiceImpl;
 import com.eod.sitree.project.ui.dto.request.ProjectCreateRequestDto;
 import com.eod.sitree.project.ui.dto.request.ProjectListRequestDto;
+import com.eod.sitree.project.ui.dto.response.ParticipatedProjectsResponseDto;
 import com.eod.sitree.project.ui.dto.response.ProjectCreateResponseDto;
 import com.eod.sitree.project.ui.dto.response.ProjectDetailResponseDto;
 import com.eod.sitree.project.ui.dto.response.ProjectLikesResponseDto;
@@ -61,6 +62,10 @@ public class ProjectService {
 
     public ProjectListResponseDto getProjectList(Pageable pageable, ProjectListRequestDto dto) {
         var result = projectRepository.getListBySearchType(pageable, dto);
+        result.getContent().forEach(p -> {
+            boolean healthy = clientRequestService.isHealthy(p.getHealthCheckUrl());
+            p.setIsHealthy(healthy);
+        });
         return new ProjectListResponseDto(result.getNumber(), result.isLast(), result.getContent());
     }
 
@@ -74,4 +79,15 @@ public class ProjectService {
     public List<SitreePickGetResponse> getSitreeSuggestion() {
         return projectRepository.getSitreeSuggestion();
     }
+
+    public List<ParticipatedProjectsResponseDto> getParticipatedProjects(Long memberId){
+        List<ParticipatedProjectsResponseDto> participatedProjects = projectRepository.getParticipatedProjects(
+                memberId);
+        participatedProjects.forEach(p -> {
+            boolean healthy = clientRequestService.isHealthy(p.getHealthCheckUrl());
+            p.setIsHealthy(healthy);
+        });
+        return participatedProjects;
+    }
+
 }

--- a/src/main/java/com/eod/sitree/project/ui/ProjectController.java
+++ b/src/main/java/com/eod/sitree/project/ui/ProjectController.java
@@ -64,4 +64,11 @@ public class ProjectController {
         var result = projectService.getSitreeSuggestion();
         return new ResponseDto<>(result);
     }
+
+    @AuthNotRequired
+    @GetMapping("/participants/{memberId}")
+    public ResponseDto<?> getParticipatedProjects(@PathVariable Long memberId){
+        var result = projectService.getParticipatedProjects(memberId);
+        return new ResponseDto<>(result);
+    }
 }

--- a/src/main/java/com/eod/sitree/project/ui/dto/response/ParticipatedProjectsResponseDto.java
+++ b/src/main/java/com/eod/sitree/project/ui/dto/response/ParticipatedProjectsResponseDto.java
@@ -1,0 +1,50 @@
+package com.eod.sitree.project.ui.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+public class ParticipatedProjectsResponseDto {
+    private final long projectId;
+    private final String name;
+    private final String thumbnail;
+    private final String shortDescription;
+    private final String backgroundImage;
+    private final long commentCount;
+    private final long likesCount;
+    private final long viewCount;
+    private final LocalDateTime latestUpdateTime;
+    private Boolean isHealthy;
+    @JsonIgnore
+    private final String healthCheckUrl;
+    private final FocusPoint focusPoint;
+
+    public ParticipatedProjectsResponseDto(long projectId, String name, String thumbnail,
+            String shortDescription, String backgroundImage, long commentCount, long likesCount,
+            long viewCount, LocalDateTime latestUpdateTime, String healthCheckUrl, long focusPointId, String focusPoint) {
+        this.projectId = projectId;
+        this.name = name;
+        this.thumbnail = thumbnail;
+        this.shortDescription = shortDescription;
+        this.backgroundImage = backgroundImage;
+        this.commentCount = commentCount;
+        this.likesCount = likesCount;
+        this.viewCount = viewCount;
+        this.latestUpdateTime = latestUpdateTime;
+        this.healthCheckUrl = healthCheckUrl;
+        this.focusPoint = focusPoint == null ? null : new FocusPoint(focusPointId, focusPoint); // 작성된 focusPoint 없으면 null 반환
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    private static class FocusPoint {
+        private final long focusPointId;
+        private final String focusPoint;
+    }
+
+    public void setIsHealthy(boolean isHealthy) {
+        this.isHealthy = isHealthy;
+    }
+}

--- a/src/main/java/com/eod/sitree/project/ui/dto/response/ProjectListResponseDto.java
+++ b/src/main/java/com/eod/sitree/project/ui/dto/response/ProjectListResponseDto.java
@@ -1,5 +1,6 @@
 package com.eod.sitree.project.ui.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Getter;
@@ -24,10 +25,12 @@ public class ProjectListResponseDto {
         private final long viewCount;
         private final LocalDateTime latestUpdateTime; // timestamp 형식
         private Boolean isHealthy;
+        @JsonIgnore
+        private final String healthCheckUrl;
 
         public ProjectDisplayElement(Long projectId, String name, String thumbnail, String shortDescription,
                 String backgroundImage, long commentCount, long likesCount, long viewCount,
-                LocalDateTime latestUpdateTime) {
+                LocalDateTime latestUpdateTime, String healthCheckUrl) {
             this.projectId = projectId;
             this.name = name;
             this.thumbnail = thumbnail;
@@ -38,6 +41,11 @@ public class ProjectListResponseDto {
             this.viewCount = viewCount;
             this.latestUpdateTime = latestUpdateTime;
             this.isHealthy = null;
+            this.healthCheckUrl = healthCheckUrl;
+        }
+
+        public void setIsHealthy(boolean isHealthy) {
+            this.isHealthy = isHealthy;
         }
     }
 }


### PR DESCRIPTION
프로젝트 목록 조회 시 HealthCheckUrl 확인되지 않고 null로 반환되고 있었던 부분 수정
GroupBy 시 select 되는 항목들 추가

마이페이지에서 유저가 참여한 프로젝트 목록 조회 API 구현