### PR TITLE
Feature/131: ranking 조회 속도 개선

### DIFF
--- a/src/main/java/com/eod/sitree/belonging/domain/modelRepository/BelongingRepository.java
+++ b/src/main/java/com/eod/sitree/belonging/domain/modelRepository/BelongingRepository.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 public interface BelongingRepository {
 
@@ -29,8 +30,9 @@ public interface BelongingRepository {
 
     List<BelongingRankingResponseDto> findBelongingByRankingAscWithProjectCount(BelongingType belongingType);
 
-    Page<BelongingRankingResponseDto> findBelongingByRankingAscWithProjectCountAsPage(
-        Pageable pageable, BelongingType belongingType);
+    Page<BelongingRankingResponseDto> findBelongingByRankingAscWithProjectCountAsPage(Pageable pageable, BelongingType belongingType);
+
+    Slice<BelongingRankingResponseDto> findBelongingByRankingAscWithProjectCountAsSlice(Pageable pageable, BelongingType belongingType);
 
     Map<Long, Belonging> findByIdsAsMap(List<Long> belongingIds);
 }

--- a/src/main/java/com/eod/sitree/belonging/infra/BelongingRepositoryImpl.java
+++ b/src/main/java/com/eod/sitree/belonging/infra/BelongingRepositoryImpl.java
@@ -24,6 +24,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -225,6 +227,50 @@ public class BelongingRepositoryImpl implements BelongingRepository {
             .orElse(0L);
 
         return new PageImpl<>(result, pageable, total);
+    }
+
+    @Override
+    public Slice<BelongingRankingResponseDto> findBelongingByRankingAscWithProjectCountAsSlice(
+        Pageable pageable, BelongingType belongingType) {
+
+        List<BelongingRankingResponseDto> result = jpaQueryFactory.select(
+                Projections.constructor(
+                    BelongingRankingResponseDto.class,
+                    belongingEntity.belongingId,
+                    belongingEntity.belongingType,
+                    belongingEntity.name,
+                    belongingEntity.imageUrl,
+                    belongingEntity.currentRanking,
+                    belongingEntity.prevRanking,
+                    projectEntity.projectId.countDistinct()
+                )
+            )
+            .from(belongingEntity)
+            .leftJoin(memberEntity)
+            .on(memberEntity.belongingId.eq(belongingEntity.belongingId))
+            .leftJoin(participantEntity)
+            .on(participantEntity.memberId.eq(memberEntity.memberId))
+            .leftJoin(projectEntity)
+            .on(projectEntity.projectId.eq(participantEntity.projectId))
+            .where(
+                eqBelongingType(belongingType, belongingEntity)
+            )
+            .groupBy(belongingEntity)
+            .orderBy(
+                orderNullsLast(belongingEntity.currentRanking, Order.ASC),
+                belongingEntity.name.asc()
+            )
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize() + 1) // has next 판단용 + 1
+            .fetch();
+
+        boolean hasNext = false;
+        if (result.size() > pageable.getPageSize()) {
+            hasNext = true;
+            result.remove(result.size() - 1); // has next 판단용 초과분 1개 제거
+        }
+
+        return new SliceImpl<>(result, pageable, hasNext);
     }
 
     @Override

--- a/src/main/java/com/eod/sitree/belonging/infra/BelongingRepositoryImpl.java
+++ b/src/main/java/com/eod/sitree/belonging/infra/BelongingRepositoryImpl.java
@@ -257,7 +257,7 @@ public class BelongingRepositoryImpl implements BelongingRepository {
                     belongingEntity.imageUrl,
                     belongingEntity.currentRanking,
                     belongingEntity.prevRanking,
-                    projectEntity.projectId.countDistinct()
+                    participantEntity.projectId.countDistinct()
                 )
             )
             .from(belongingEntity)
@@ -265,8 +265,6 @@ public class BelongingRepositoryImpl implements BelongingRepository {
             .on(memberEntity.belongingId.eq(belongingEntity.belongingId))
             .leftJoin(participantEntity)
             .on(participantEntity.memberId.eq(memberEntity.memberId))
-            .leftJoin(projectEntity)
-            .on(projectEntity.projectId.eq(participantEntity.projectId))
             .where(
                 belongingEntity.belongingId.in(belongingIds)
             )

--- a/src/main/java/com/eod/sitree/belonging/service/BelongingService.java
+++ b/src/main/java/com/eod/sitree/belonging/service/BelongingService.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -30,8 +31,8 @@ public class BelongingService {
         return belongingRepository.findBelongingByRankingAscWithProjectCount(request.getBelongingType());
     }
 
-    public Page<BelongingRankingResponseDto> searchRanking(BelongingRankingRequestDto request) {
+    public Slice<BelongingRankingResponseDto> searchRanking(BelongingRankingRequestDto request) {
 
-        return belongingRepository.findBelongingByRankingAscWithProjectCountAsPage(request.getPageable(), request.getBelongingType());
+        return belongingRepository.findBelongingByRankingAscWithProjectCountAsSlice(request.getPageable(), request.getBelongingType());
     }
 }

--- a/src/main/java/com/eod/sitree/belonging/ui/BelongingController.java
+++ b/src/main/java/com/eod/sitree/belonging/ui/BelongingController.java
@@ -8,6 +8,7 @@ import com.eod.sitree.belonging.ui.dto.request.BelongingRankingRequestDto;
 import com.eod.sitree.belonging.ui.dto.request.BelongingSearchRequestDto;
 import com.eod.sitree.belonging.ui.dto.response.BelongingRankingPageResponseDto;
 import com.eod.sitree.belonging.ui.dto.response.BelongingRankingResponseDto;
+import com.eod.sitree.belonging.ui.dto.response.BelongingRankingSliceResponseDto;
 import com.eod.sitree.belonging.ui.dto.response.BelongingSearchPageResponseDto;
 import com.eod.sitree.common.response.ResponseDto;
 import java.util.List;
@@ -33,8 +34,8 @@ public class BelongingController {
 
     @AuthNotRequired
     @GetMapping("/ranking")
-    public ResponseDto<BelongingRankingPageResponseDto> rankBelongings(BelongingRankingRequestDto request) {
+    public ResponseDto<BelongingRankingSliceResponseDto> rankBelongings(BelongingRankingRequestDto request) {
 
-        return ResponseDto.ok(new BelongingRankingPageResponseDto(belongingService.searchRanking(request)));
+        return ResponseDto.ok(new BelongingRankingSliceResponseDto(belongingService.searchRanking(request)));
     }
 }

--- a/src/main/java/com/eod/sitree/belonging/ui/dto/response/BelongingRankingSliceResponseDto.java
+++ b/src/main/java/com/eod/sitree/belonging/ui/dto/response/BelongingRankingSliceResponseDto.java
@@ -1,0 +1,16 @@
+package com.eod.sitree.belonging.ui.dto.response;
+
+import com.eod.sitree.common.response.BasePageResponse;
+import com.eod.sitree.common.response.BaseSliceResponse;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
+
+@Getter
+public class BelongingRankingSliceResponseDto extends BaseSliceResponse<BelongingRankingResponseDto> {
+
+    public BelongingRankingSliceResponseDto(Slice slice) {
+
+        super(slice);
+    }
+}

--- a/src/main/java/com/eod/sitree/common/response/BaseSliceResponse.java
+++ b/src/main/java/com/eod/sitree/common/response/BaseSliceResponse.java
@@ -1,0 +1,28 @@
+package com.eod.sitree.common.response;
+
+import java.util.List;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
+
+@Getter
+public class BaseSliceResponse<T> {
+
+    private List<T> content;
+
+    private int page;
+
+    private int size;
+
+    private boolean hasPrev;
+
+    private boolean hasNext;
+
+    public BaseSliceResponse(Slice<T> slice) {
+        this.content = slice.getContent();
+        this.page = slice.getPageable().getPageNumber();
+        this.size = slice.getPageable().getPageSize();
+        this.hasPrev = slice.hasPrevious();
+        this.hasNext = slice.hasNext();
+    }
+}


### PR DESCRIPTION
ranking 조회 속도 개선

적용방안

- page -> slice로 반환 구조 변경 -> total element 계산을 위해 풀스캔하는 것을 방지
- left join 하기전 order 된 belonging id만 먼저 페이지 사이즈에 맞게 가져온 후 2차 쿼리로 매쉬업 -> 1:N:N:N 관계에서 카디널리티 폭발(cardinality explosion) 발생 가능성 제거
- DB 인덱스 설정  